### PR TITLE
Use the Property options :messages from dm-validations if define

### DIFF
--- a/lib/devise/orm/data_mapper/validations/dm-validations.rb
+++ b/lib/devise/orm/data_mapper/validations/dm-validations.rb
@@ -13,7 +13,8 @@ if Devise.data_mapper_validation_lib == 'dm-validations'
         # the message, including translation.
         def add(field_name, message = nil, active_record_options = {})
           if message.kind_of?(Symbol)
-            message = self.class.default_error_message(message, field_name, active_record_options.values)
+            message = resource.class.properties[:email].options[:messages][message] ||
+              self.class.default_error_message(message, field_name, active_record_options.values)
           end
           original_add(field_name, message) unless errors[field_name].include?(message)
         end

--- a/lib/devise/orm/data_mapper/validations/dm-validations.rb
+++ b/lib/devise/orm/data_mapper/validations/dm-validations.rb
@@ -13,8 +13,7 @@ if Devise.data_mapper_validation_lib == 'dm-validations'
         # the message, including translation.
         def add(field_name, message = nil, active_record_options = {})
           if message.kind_of?(Symbol)
-            message = resource.class.properties[:email].options[:messages][message] ||
-              self.class.default_error_message(message, field_name, active_record_options.values)
+            message = get_message(field_name, message, active_record_options)
           end
           original_add(field_name, message) unless errors[field_name].include?(message)
         end
@@ -23,6 +22,19 @@ if Devise.data_mapper_validation_lib == 'dm-validations'
         # #to_xml. Otherwise, we get a Missing template error
         def to_xml(options = {})
           @errors.to_hash.to_xml(options.merge(:root => 'errors'))
+        end
+
+        private
+
+        ##
+        # verify if a message is already define in property and use is if possible
+        #
+        def get_message(field_name, message = nil, active_record_options = {})
+          if resource.class.properties[:email].options[:messages]
+            resource.class.properties[:email].options[:messages][message]
+          else
+            self.class.default_error_message(message, field_name, active_record_options.values)
+          end
         end
       end
     end


### PR DESCRIPTION
To change error message, you can do only by default overriding.
dm-validations add an option to property allow overriding this message.
This commit use it if it's define.
